### PR TITLE
Handle errors instead of panicking and remove tokio_scoped dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4457,27 +4457,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-scoped"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4beb8ba13bc53ac53ce1d52b42f02e5d8060f0f42138862869beb769722b256"
-dependencies = [
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4651,7 +4630,6 @@ dependencies = [
  "spin-core",
  "spin-trigger",
  "tokio",
- "tokio-scoped",
  "tracing",
  "tracing-subscriber",
  "wasmtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,13 @@ serde = "1.0.188"
 spin-app = { git = "https://github.com/fermyon/spin" }
 spin-core = { git = "https://github.com/fermyon/spin" }
 spin-trigger = { git = "https://github.com/fermyon/spin" }
-tokio = { version = "1.11", features = [ "full" ] }
-tokio-scoped = "0.2.0"
+tokio = { version = "1.11", features = ["full"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3.7", features = ["env-filter"] }
-paho-mqtt = { version = "0.12.3", default-features = false, features = ["vendored-ssl"] }
-wasmtime = { version = "18.0.1", features = ["component-model"]}
+paho-mqtt = { version = "0.12.3", default-features = false, features = [
+    "vendored-ssl",
+] }
+wasmtime = { version = "18.0.1", features = ["component-model"] }
 
 [workspace]
 members = ["sdk", "sdk/macro"]


### PR DESCRIPTION
This PR addresses the unwraps and also removes the dependency on `tokio_scoped` as the project has been [archived](https://github.com/jaboatman/tokio-scoped). If one of the listeners fails, all the others are dropped as well to not have a partially running app. 